### PR TITLE
make functions an instance of MonadReaderN and MonadLocalN

### DIFF
--- a/Control/Monad/Classes/Reader.hs
+++ b/Control/Monad/Classes/Reader.hs
@@ -11,6 +11,8 @@ import Data.Peano
 
 type instance CanDo (R.ReaderT e m) eff = ReaderCanDo e eff
 
+type instance CanDo ((->) e) eff = ReaderCanDo e eff
+
 type family ReaderCanDo e eff where
   ReaderCanDo e (EffReader e) = True
   ReaderCanDo e (EffLocal e) = True
@@ -27,6 +29,9 @@ instance Monad m => MonadReaderN Zero r (SL.StateT r m) where
 
 instance Monad m => MonadReaderN Zero r (SS.StateT r m) where
   askN _ = SS.get
+
+instance MonadReaderN Zero r ((->) r) where
+  askN _ = id
 
 instance (MonadTrans t, Monad (t m), MonadReaderN n r m, Monad m)
   => MonadReaderN (Succ n) r (t m)
@@ -52,6 +57,9 @@ instance (Monad m) => MonadLocalN Zero r (SL.StateT r m) where
 
 instance (Monad m) => MonadLocalN Zero r (SS.StateT r m) where
   localN _ = stateLocal SS.put SS.get
+
+instance MonadLocalN Zero r ((->) r) where
+  localN _ = flip (.)
 
 instance (MonadTrans t, Monad (t m), MFunctor t, MonadLocalN n r m, Monad m)
   => MonadLocalN (Succ n) r (t m)

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -35,7 +35,8 @@ main = defaultMain tests
 
 tests :: TestTree
 tests = testGroup "Tests"
-  [ simpleStateTests
+  [ readerTests
+  , simpleStateTests
   , twoStatesTests
   , liftingTest
   , localState
@@ -46,6 +47,28 @@ tests = testGroup "Tests"
   , liftConduitTest
   , mapWriterTest
   ]
+
+readerTests = testGroup "Reader Tests"
+  [ testCase "ask" $
+      let base = 5 :: Integer
+          power = 3 :: Int
+          expected = 125 :: Integer
+      in (runReader power action) base @?= expected
+  , testCase "local ask" $
+      let base = 5 :: Integer
+          power = 2 :: Int
+          altBase = 7 :: Integer
+          altPower = 3 :: Int
+          expected = 174 :: Integer
+          action' = do
+            x <- local (const altBase) action
+            y <- local (const altPower) action
+            pure (x + y)
+      in (runReader power action') base @?= expected
+  ]
+  where
+    f = (^) :: Integer -> Int -> Integer
+    action = f <$> ask <*> ask
 
 simpleStateTests = testGroup "Simple State"
   [ testCase "get" $


### PR DESCRIPTION
My motivation is that I want to write versions of lens operators that work with monad-classes instead of the mtl, and that in particular, I want to retain the ability to use `view` on simple reader types (`(->) r`) as well as on more complex monad stacks.