### PR TITLE
[WIP] Add custom type errors

### DIFF
--- a/Control/Monad/Classes/Except.hs
+++ b/Control/Monad/Classes/Except.hs
@@ -7,6 +7,7 @@ import Control.Monad.Trans.Class
 import GHC.Prim (Proxy#, proxy#)
 import Control.Monad.Classes.Core
 import Control.Monad.Classes.Effects
+import Control.Monad.Classes.TypeErrors
 import Data.Peano (Peano (..))
 
 type instance CanDo IO (EffExcept e) = True
@@ -35,6 +36,11 @@ instance (MonadTrans t, Monad (t m), MonadExceptN n e m, Monad m)
   => MonadExceptN (Succ n) e (t m)
   where
     throwN _ = lift . throwN (proxy# :: Proxy# n)
+
+instance {-# INCOHERENT #-} (InstanceNotFoundError "MonadExcept" e m, Monad m)
+  => MonadExceptN n e m
+  where
+    throwN = error "unreachable"
 
 -- | The @'MonadExcept' e m@ constraint asserts that @m@ is a monad stack
 -- that supports throwing exceptions of type @e@

--- a/Control/Monad/Classes/Exec.hs
+++ b/Control/Monad/Classes/Exec.hs
@@ -9,6 +9,7 @@ import Control.Monad.Trans.Class
 import GHC.Prim (Proxy#, proxy#)
 import Control.Monad.Classes.Core
 import Control.Monad.Classes.Effects
+import Control.Monad.Classes.TypeErrors
 import Data.Peano (Peano (..))
 
 type instance CanDo IO (EffExec IO) = True
@@ -23,6 +24,11 @@ instance (MonadTrans t, Monad (t m), MonadExecN n w m, Monad m)
   => MonadExecN (Succ n) w (t m)
   where
     execN _ = lift . execN (proxy# :: Proxy# n)
+
+instance {-# INCOHERENT #-} (InstanceNotFoundError "MonadExec" w m, Monad m)
+  => MonadExecN n w m
+  where
+    execN = error "unreachable"
 
 type MonadExec w m = MonadExecN (Find (EffExec w) m) w m
 

--- a/Control/Monad/Classes/State.hs
+++ b/Control/Monad/Classes/State.hs
@@ -5,6 +5,7 @@ import Control.Monad.Trans.Class
 import GHC.Prim (Proxy#, proxy#)
 import Control.Monad.Classes.Core
 import Control.Monad.Classes.Effects
+import Control.Monad.Classes.TypeErrors
 import Data.Peano (Peano (..))
 
 type instance CanDo (SS.StateT s m) eff = StateCanDo s eff
@@ -30,6 +31,11 @@ instance (Monad (t m), MonadTrans t, MonadStateN n s m, Monad m)
   => MonadStateN (Succ n) s (t m)
   where
     stateN _ = lift . stateN (proxy# :: Proxy# n)
+
+instance {-# INCOHERENT #-} (InstanceNotFoundError "MonadState" s m, Monad m)
+  => MonadStateN n s m
+  where
+    stateN = error "unreachable"
 
 -- | The @'MonadState' s m@ constraint asserts that @m@ is a monad stack
 -- that supports state operations on type @s@

--- a/Control/Monad/Classes/TypeErrors.hs
+++ b/Control/Monad/Classes/TypeErrors.hs
@@ -1,0 +1,9 @@
+module Control.Monad.Classes.TypeErrors where
+
+import GHC.TypeLits
+
+type family InstanceNotFoundError name param m where
+  InstanceNotFoundError name param m =
+    TypeError (Text "Control.Monad.Classes:" :$$:
+               Text name :<>: Text " (" :<>: ShowType param :<>: Text ")" :<>:
+               Text " instance not found for " :<>: ShowType m)

--- a/Control/Monad/Classes/Writer.hs
+++ b/Control/Monad/Classes/Writer.hs
@@ -12,6 +12,7 @@ import Control.Monad.IO.Class
 import Control.Monad.Classes.Core
 import Control.Monad.Classes.Effects
 import Control.Monad.Classes.Proxied
+import Control.Monad.Classes.TypeErrors
 import Data.Monoid
 import Data.Peano
 
@@ -49,6 +50,11 @@ instance (MonadTrans t, Monad (t m), MonadWriterN n w m, Monad m)
   => MonadWriterN (Succ n) w (t m)
   where
     tellN _ = lift . tellN (proxy# :: Proxy# n)
+
+instance {-# INCOHERENT #-} (InstanceNotFoundError "MonadWriter" w m, Monad m)
+  => MonadWriterN n w m
+  where
+    tellN = error "unreachable"
 
 -- | The @'MonadWriter' w m@ constraint asserts that @m@ is a monad stack
 -- that supports outputting values of type @w@

--- a/monad-classes.cabal
+++ b/monad-classes.cabal
@@ -32,7 +32,8 @@ library
     Control.Monad.Classes.Zoom,
     Control.Monad.Classes.Core,
     Control.Monad.Classes.Effects,
-    Control.Monad.Classes.ReadState
+    Control.Monad.Classes.ReadState,
+    Control.Monad.Classes.TypeErrors
   build-depends:
     base >=4.7 && <5,
     peano >=0.1,

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -62,6 +62,8 @@ readerTests = testGroup "Reader Tests"
           altBase = 7 :: Integer
           altPower = 3 :: Int
           expected = 174 :: Integer
+          action' :: ( MonadLocal Int m, MonadLocal Integer m
+                     , MonadReader Int m, MonadReader Integer m ) => m Integer
           action' = do
             x <- local (const altBase) action
             y <- local (const altPower) action
@@ -70,6 +72,7 @@ readerTests = testGroup "Reader Tests"
   ]
   where
     f = (^) :: Integer -> Int -> Integer
+    action :: (MonadReader Int m, MonadReader Integer m) => m Integer
     action = f <$> ask <*> ask
 
 simpleStateTests = testGroup "Simple State"
@@ -81,6 +84,7 @@ simpleStateTests = testGroup "Simple State"
       (run $ runStateLazy (0 :: Int) (put (1 :: Int) *> get <* put (2 :: Int))) @?= (1 :: Int, 2 :: Int)
   ]
 
+twoStatesComp :: (MonadState Char m, MonadState Bool m) => m ()
 twoStatesComp = put 'b' >> put True >> put 'c'
 
 twoStatesTests = testCase "Two States" $


### PR DESCRIPTION
Type errors from `monad-classes` can get hairy. For example, this snippet

```haskell
import Control.Monad.Classes (MonadWriter, tell)

foo :: Monad m => m ()
foo = tell [True]
```

Produces the following error:

```
    • Could not deduce (Control.Monad.Classes.Writer.MonadWriterN
                          (Control.Monad.Classes.Core.FindTrue
                             (Control.Monad.Classes.Core.MapCanDo
                                (Control.Monad.Classes.Effects.EffWriter [Bool]) m))
                          [Bool]
                          m)
        arising from a use of ‘tell’
      from the context: Monad m
```

When the import list is removed, it can be shortened to this:

```
    • Could not deduce (MonadWriterN
                          (FindTrue (MapCanDo (EffWriter [Bool]) m)) [Bool] m)
        arising from a use of ‘tell’
```

However, this still exposes the library internals and is less readable than errors from plain `mtl`.

I've found a way to make errors look like this:

```
    • Control.Monad.Classes:
      MonadWriter ([Bool]) instance not found for m
```

using GHC 8 `TypeError` and `{-# INCOHERENT #-}` instances.

But if has a big cost: When inferring types, GHC for some reason picks the "error" instance:

```haskell
foo = tell [True]

--    • Control.Monad.Classes:
--      MonadWriter ([Bool]) instance not found for m0
--    • In the expression: tell [True]
--      In an equation for ‘foo’: foo = tell [True]
```

So you always have to write type signatures. Which is a good thing by the way, but it's certainly a breaking change.

What do you think?