### PR TITLE
Tweak ReadStateT MonadTransControl instance for GHC 8.2

### DIFF
--- a/Control/Monad/Classes/ReadState.hs
+++ b/Control/Monad/Classes/ReadState.hs
@@ -39,7 +39,7 @@ instance MonadBase b m => MonadBase b (ReadStateT x m) where
   liftBase = lift . liftBase
 
 instance MonadTransControl (ReadStateT x) where
-  type StT (ReadStateT s) a = StT IdentityT a
+  type StT (ReadStateT x) a = StT IdentityT a
   liftWith = defaultLiftWith ReadStateT (\(ReadStateT a) -> a)
   restoreT = defaultRestoreT ReadStateT
 


### PR DESCRIPTION
GHC 8.2.1 is more strict in the way type variables can be used in associated
types. The error is:
```
/home/enolan/code/signalvine/monad-classes.hs/Control/Monad/Classes/ReadState.hs:42:8: error:
    • Type indexes must match class instance head
      Expected: StT (ReadStateT x) <tv>
        Actual: StT (ReadStateT s) a
      where the `<tv>' arguments are type variables,
      distinct from each other and from the instance variables
    • In the type instance declaration for ‘StT’
      In the instance declaration for ‘MonadTransControl (ReadStateT x)’
   |
42 |   type StT (ReadStateT s) a = StT IdentityT a
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
This commit fixes it.